### PR TITLE
feat: 로그인 관련 로딩, 에러 처리 구현

### DIFF
--- a/src/app/oauth/page.tsx
+++ b/src/app/oauth/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import useSignInMutation from '@/components/Oauth/hooks/useSignInMutation';
+import { Loading } from '@/shared/ui/Icon';
 import { useSearchParams } from 'next/navigation';
 import { useEffect } from 'react';
 
@@ -21,7 +22,13 @@ const Oauth = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  return null;
+  return (
+    <div className="absolute inset-0 flex justify-center items-center">
+      <Loading textClassName="text-center">
+        로그인 중입니다. <br /> 잠시만 기다려주세요!
+      </Loading>
+    </div>
+  );
 };
 
 export default Oauth;

--- a/src/components/Login/SocialLogin.tsx
+++ b/src/components/Login/SocialLogin.tsx
@@ -32,7 +32,7 @@ const SNS_MAP: SocialLoginProps[] = [
 
 const SocialLogin = () => {
   return (
-    <div className="flex flex-col gap-5 mt-[40px]">
+    <div className="flex flex-col gap-5 mt-[40px] mb-[40px]">
       <span className="text-sm lg:text-base font-normal text-gray-6E">
         SNS로 바로 시작하기
       </span>

--- a/src/components/Oauth/hooks/useSignInMutation.ts
+++ b/src/components/Oauth/hooks/useSignInMutation.ts
@@ -8,7 +8,9 @@ const useSignInMutation = (provider: string) => {
   return useMutation({
     mutationFn: async (data: AuthProps) => {
       const response = await postSimpleSignIn(provider, data);
-      if (!response.ok) {
+      if (response.status === 403) {
+        throw new Error('Forbidden');
+      } else if (!response.ok) {
         const errorData = await response.json();
         throw new Error(errorData.message);
       }
@@ -19,8 +21,12 @@ const useSignInMutation = (provider: string) => {
       router.push('/');
     },
     onError: (error) => {
-      alert(error.message);
-      router.push('/oauth/register');
+      if (error.message === 'Forbidden') {
+        router.push('/oauth/register');
+      } else {
+        alert(error.message);
+        router.push('/');
+      }
     },
   });
 };

--- a/src/shared/ui/Icon/Loading.tsx
+++ b/src/shared/ui/Icon/Loading.tsx
@@ -12,7 +12,7 @@ export const Loading = ({
     <div className="flex flex-col items-center gap-3">
       <LoadingIcon
         className={twMerge(
-          'mobile:w-[39.2px] mobile:h-[32px] w-[39.2px] h-[32px] lg:w-[49px] lg:h-[40px] fill-gray-6E',
+          'mobile:w-[39px] mobile:h-[32px] w-[39px] h-[32px] lg:w-[49px] lg:h-[40px] fill-gray-6E',
           iconClassName,
         )}
       />


### PR DESCRIPTION
## #️⃣연관된 이슈

> #104 

## 📝작업 내용

> 로그인 시도 중 로딩 화면
> 로그인 페이지에서 소셜 로그인 밑에 margin-bottom 적용

### 스크린샷 (선택)
![image](https://github.com/Codeit-Part4-SFJs/WDYTA/assets/129318957/87a64a78-ca26-4e48-ac1c-9f00ee7701c4)

https://github.com/Codeit-Part4-SFJs/WDYTA/assets/129318957/d22838c3-8c2a-4e08-9ccd-527a90401909



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 간편 로그인 에러 화면을 구현을 하긴 했습니다! 
> 회원이 아닐 경우 회원이 아닙니다 모달이 나와서 회원가입으로 넘어가도록 구현할 예정입니다.
> 근데 간편 로그인 관련 에러도 에러 문구가 나오고 버튼 클릭해서 홈으로 이동하는거라 둘다 모달로 통일하는건 어떤지 논의를 한 후 PR에 올리는 게 좋을 것 같아서 이번 PR에서는 올리지 않았습니다!
