### PR TITLE
feat : 상품 편집 모달 구현

### DIFF
--- a/src/app/@modal/(.)modal/detail/edit/page.tsx
+++ b/src/app/@modal/(.)modal/detail/edit/page.tsx
@@ -1,0 +1,14 @@
+import { EditModal } from '@/components/Detail/modal';
+import { Modal } from '@/shared/ui/Modal';
+import { cookies } from 'next/headers';
+
+const ProductEditModal = () => {
+  const accessToken = cookies().get('accessToken')?.value ?? '';
+  return (
+    <Modal size="large" closeIcon>
+      <EditModal accessToken={accessToken} />
+    </Modal>
+  );
+};
+
+export default ProductEditModal;

--- a/src/app/modal/detail/edit/page.tsx
+++ b/src/app/modal/detail/edit/page.tsx
@@ -1,0 +1,14 @@
+import { EditModal } from '@/components/Detail/modal';
+import { Modal } from '@/shared/ui/Modal';
+import { cookies } from 'next/headers';
+
+const ProductEditModal = () => {
+  const accessToken = cookies().get('accessToken')?.value ?? '';
+  return (
+    <Modal size="large" closeIcon>
+      <EditModal accessToken={accessToken} />
+    </Modal>
+  );
+};
+
+export default ProductEditModal;

--- a/src/components/@common/modal/constants/CATEGORY_DROPDOWN_OPTIONS.ts
+++ b/src/components/@common/modal/constants/CATEGORY_DROPDOWN_OPTIONS.ts
@@ -20,7 +20,6 @@ async function fetchCategories(): Promise<Category[]> {
 export const CATEGORY_DROPDOWN_OPTIONS = async () => {
   const categories = await fetchCategories();
   const categoryList: Category[] = categories ?? DEFAULT_CATEGORIES;
-  console.log(categoryList);
 
   // 카테고리 선택 드롭다운 옵션
   return categoryList.map((category) => ({

--- a/src/components/Detail/ProductDetail/ProductDetail.tsx
+++ b/src/components/Detail/ProductDetail/ProductDetail.tsx
@@ -90,6 +90,7 @@ export const ProductDetail = ({
               onClick={() => {
                 router.push(
                   `/modal/detail/edit?productId=${productId}&productName=${productDetailData.name}&category=${productDetailData.categoryId}&image=${productDetailData.image}`,
+                  { scroll: false },
                 );
               }}
             >

--- a/src/components/Detail/ProductDetail/ProductDetail.tsx
+++ b/src/components/Detail/ProductDetail/ProductDetail.tsx
@@ -87,6 +87,11 @@ export const ProductDetail = ({
             <Button
               customSize="flex-1 w-full p-[15px]"
               kind={ButtonKind.tertiary}
+              onClick={() => {
+                router.push(
+                  `/modal/detail/edit?productId=${productId}&productName=${productDetailData.name}&category=${productDetailData.categoryId}&image=${productDetailData.image}`,
+                );
+              }}
             >
               편집하기
             </Button>

--- a/src/components/Detail/ProductDetail/hooks/index.ts
+++ b/src/components/Detail/ProductDetail/hooks/index.ts
@@ -1,1 +1,2 @@
 export * from '@/components/Detail/ProductDetail/hooks/useFavoriteMutation';
+export * from '@/components/Detail/ProductDetail/hooks/useEditProductMutation';

--- a/src/components/Detail/ProductDetail/hooks/useEditProductMutation.ts
+++ b/src/components/Detail/ProductDetail/hooks/useEditProductMutation.ts
@@ -1,0 +1,34 @@
+import { ProductProps, patchProduct } from '@/shared/@common/apis/product';
+import { useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+interface EditProductProps {
+  accessToken: string;
+  setErrorMessage: (message: string) => void;
+  productId: number;
+}
+
+export const useEditProductMuation = ({
+  accessToken,
+  setErrorMessage,
+  productId,
+}: EditProductProps) => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: async (data: ProductProps) => {
+      const response = await patchProduct(productId, data, accessToken);
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message);
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      router.back();
+    },
+    onError: (error) => {
+      setErrorMessage(error.message);
+    },
+  });
+};

--- a/src/components/Detail/modal/EditModal.tsx
+++ b/src/components/Detail/modal/EditModal.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { FormValues } from '@/shared/@common/types/input';
+import { Dropdown, DropdownKind } from '@/shared/ui/Dropdown/Dropdown';
+import HelperText from '@/shared/ui/Input/HelperText';
+import { TextBoxInput } from '@/shared/ui/Input/TextBox';
+import { ImageInput } from '@/shared/ui/Input/image';
+import { ProductInput } from '@/shared/ui/Input/product/ProductInput';
+import { useEffect, useState } from 'react';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { handleDeleteButton, handleImageChange } from '@/shared/@common/utils';
+import { useImageMutation } from '@/shared/@common/hooks';
+import { Button, ButtonKind } from '@/shared/ui/Button/Button';
+import { ProductCategoryEnum } from '@/shared/ui/Chip/types/categoryChipType';
+import { useSearchParams } from 'next/navigation';
+import { CATEGORY_DROPDOWN_OPTIONS } from '../../@common/modal/constants/CATEGORY_DROPDOWN_OPTIONS';
+import { useEditProductMuation } from '../ProductDetail/hooks';
+
+interface EditModalProps {
+  accessToken: string;
+}
+export const EditModal = ({ accessToken }: EditModalProps) => {
+  const {
+    register,
+    watch,
+    handleSubmit,
+    formState: { errors },
+  } = useForm<FormValues>({
+    mode: 'onChange',
+  });
+  const params = useSearchParams();
+  const productId = parseInt(params.get('productId') as string, 10);
+  const categoryId = params.get('category') || '';
+  const productName = params.get('productName') || '';
+  const image = params.get('image') || '';
+
+  const [file, setFile] = useState<File | null>(null);
+  const [preview, setPreview] = useState(image);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [options, setOptions] = useState<{ value: string; label: string }[]>(
+    [],
+  );
+  const [category, setCategory] = useState(categoryId);
+
+  const text = watch('textarea', '');
+
+  const imageMutation = useImageMutation({ accessToken, setErrorMessage });
+  const editProductMutation = useEditProductMuation({
+    accessToken,
+    setErrorMessage,
+    productId,
+  });
+
+  useEffect(() => {
+    const loadOptions = async () => {
+      const fetchedOptions = await CATEGORY_DROPDOWN_OPTIONS();
+      setOptions(fetchedOptions);
+    };
+
+    loadOptions();
+  }, []);
+
+  const handleProductCategory = (productCategory: string) => {
+    setCategory(productCategory);
+  };
+
+  const onSubmit: SubmitHandler<FormValues> = (productData) => {
+    if (file) {
+      imageMutation.mutate(file, {
+        onSuccess: (data) => {
+          editProductMutation.mutate({
+            categoryId: Number(category),
+            image: data.url,
+            description: text,
+            name: productData.productName,
+          });
+        },
+      });
+    } else {
+      editProductMutation.mutate({
+        categoryId: Number(category),
+        image: preview, // 기존 이미지를 사용
+        description: text,
+        name: productData.productName,
+      });
+    }
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-[40px] mobile:gap-5"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <span className="text-gray-F1 text-xl lg:text-2xl font-semibold lg:leading-none">
+        상품 편집
+      </span>
+      <div className="flex flex-col gap-[10px] md:gap-[15px] lg:gap-5">
+        <div className="flex mobile:flex-col-reverse gap-[10px] md:gap-[15px] lg:gap-5">
+          <div className="flex flex-col">
+            <ProductInput
+              register={register}
+              errors={errors}
+              productName={productName}
+            />
+            <Dropdown
+              options={options}
+              onSelect={handleProductCategory}
+              kind={DropdownKind.modal}
+              placeholder={ProductCategoryEnum[Number(categoryId)]}
+            />
+          </div>
+          <ImageInput
+            previewImage={preview}
+            handleDeleteButton={() => handleDeleteButton({ setPreview })}
+            handleImageChange={(event) =>
+              handleImageChange({ event, setFile, setPreview })
+            }
+          />
+        </div>
+        <TextBoxInput
+          register={register}
+          text={text}
+          placeholder="상품 설명을 입력해 주세요"
+        />
+        {errorMessage && <HelperText type="error">{errorMessage}</HelperText>}
+      </div>
+      <Button
+        type="submit"
+        kind={ButtonKind.primary}
+        customSize="lg:text-lg w-[295px] md:w-[510px] lg:w-[540px] h-[50px] md:h-[55px] lg:h-[65px]"
+      >
+        저장하기
+      </Button>
+    </form>
+  );
+};

--- a/src/components/Detail/modal/index.ts
+++ b/src/components/Detail/modal/index.ts
@@ -1,1 +1,2 @@
 export * from './ReviewModal';
+export * from './EditModal';


### PR DESCRIPTION
## #️⃣연관된 이슈

> #146 

## 📝작업 내용

> 상품 편집 모달 구현 완료!

상품 편집하기를 누르면 모달이 뜨고 상품명, 카테고리, 사진만 router.push할 때 값들을 넘겨주고 이를 편집 모달이 뜰 때 미리 입력된 채로 구현을 했습니다.
상품 설명 부분은 router.push로 받아오기에 너무 긴 글이 쿼리스트링으로 들어가는 것은 조금 아니라고 생각해서 비워두게되었습니다!
이미지를 선택했을 경우, 선택하지 않았을 경우에 따라 mutation을 다르게 동작하도록 구현해놨습니다!

### 스크린샷 (선택)
![image](https://github.com/Codeit-Part4-SFJs/WDYTA/assets/129318957/74692bac-9e0d-45ac-ab81-350f24340e91)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 이미지도 쿼리스트링으로 하는게 맞나? 싶긴 합니다... 
> 지금은 새로고침을 해야 patch 된 상황을 확인할 수 있는데 이 부분은 @suMin-97 님과 얘기하여 새로고침하지 않아도 반영될 수 있게 물어보고 적용해야할 것 같아 남겨뒀습니다.
> 버튼 disabled는 다른 이슈에서 상품 리뷰, 상품 편집 모달 함께 작업하고자 합니다!
