### PR TITLE
feat : 이미지 Input 확장자 제한하기

### DIFF
--- a/src/components/Detail/modal/ReviewModal.tsx
+++ b/src/components/Detail/modal/ReviewModal.tsx
@@ -12,6 +12,7 @@ import { useState } from 'react';
 import { useSearchParams } from 'next/navigation';
 import { SubmitHandler, useForm } from 'react-hook-form';
 import { useQueryClient } from '@tanstack/react-query';
+import { ALLOWED_TYPES } from '@/shared/@common/utils/constants/Image';
 import { useCreateReviewMutation } from '../ProductReviews/hooks/useCreateReviewMutation';
 
 interface ReviewModalProps {
@@ -74,6 +75,12 @@ export const ReviewModal = ({ accessToken }: ReviewModalProps) => {
             alert('이미지 파일의 최대 용량은 5MB입니다.');
             return false;
           }
+
+          if (!ALLOWED_TYPES.includes(file.type)) {
+            alert('허용된 파일 형식은 .jpg, .jpeg, .png, .webp 입니다.');
+            return false;
+          }
+
           return true;
         })
         .map((file) => {

--- a/src/shared/@common/utils/changeImage.ts
+++ b/src/shared/@common/utils/changeImage.ts
@@ -1,10 +1,10 @@
+import { ALLOWED_TYPES, MAX_SIZE } from './constants/Image';
+
 interface ImageChangeProps {
   event: React.ChangeEvent<HTMLInputElement>;
   setFile: React.Dispatch<React.SetStateAction<File | null>>;
   setPreview: React.Dispatch<React.SetStateAction<string>>;
 }
-
-const MAX_SIZE = 5 * 1024 * 1024;
 
 export const handleImageChange = ({
   event,
@@ -12,14 +12,18 @@ export const handleImageChange = ({
   setPreview,
 }: ImageChangeProps) => {
   const selectedFile = event.target.files?.[0] || null;
-  // const fileName = selectedFile.name;
-
-  if (selectedFile && selectedFile.size > MAX_SIZE) {
-    alert('이미지 파일의 최대 용량은 5MB입니다.');
-    return;
-  }
 
   if (selectedFile) {
+    if (selectedFile && selectedFile.size > MAX_SIZE) {
+      alert('이미지 파일의 최대 용량은 5MB입니다.');
+      return;
+    }
+
+    if (!ALLOWED_TYPES.includes(selectedFile.type)) {
+      alert('허용된 파일 형식은 .jpg, .jpeg, .png, .webp 입니다.');
+      return;
+    }
+
     const newFileName = Math.random().toString(36).substring(2, 8);
     const newFile = new File([selectedFile], newFileName, {
       type: selectedFile.type,

--- a/src/shared/@common/utils/constants/Image.ts
+++ b/src/shared/@common/utils/constants/Image.ts
@@ -1,0 +1,2 @@
+export const MAX_SIZE = 5 * 1024 * 1024;
+export const ALLOWED_TYPES = ['image/jpeg', 'image/png', 'image/webp'];


### PR DESCRIPTION
## #️⃣연관된 이슈

> #154 

## 📝작업 내용

> 이미지 Input 확장자 제한하기

### 스크린샷 (선택)
- 다음과 같이 우선 alert로 해놨습니다!
https://github.com/Codeit-Part4-SFJs/WDYTA/assets/129318957/bfff259c-841f-4868-a2fb-9e5579b4fed3

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> 우선 jpg, jpeg, png, webp 가능하도록 했습니다!! 더 추가해야할 이미지 확장자가 있으면 말해주세요!
