### PR TITLE
refactor: 배포 주소에 HTTPS 적용 및 상품 상세 페이지 리팩토링

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wdyta",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "type": "module",
   "private": true,
   "scripts": {

--- a/src/app/@modal/(.)modal/detail/reviewEdit/page.tsx
+++ b/src/app/@modal/(.)modal/detail/reviewEdit/page.tsx
@@ -1,0 +1,15 @@
+import { ReviewEditModal } from '@/components/Detail/modal';
+import { Modal } from '@/shared/ui/Modal';
+import { cookies } from 'next/headers';
+
+const ProductReviewEditModal = () => {
+  const accessToken = cookies().get('accessToken')?.value ?? '';
+
+  return (
+    <Modal size="medium" closeIcon>
+      <ReviewEditModal accessToken={accessToken} />
+    </Modal>
+  );
+};
+
+export default ProductReviewEditModal;

--- a/src/app/modal/detail/reviewEdit/page.tsx
+++ b/src/app/modal/detail/reviewEdit/page.tsx
@@ -1,0 +1,15 @@
+import { ReviewEditModal } from '@/components/Detail/modal';
+import { Modal } from '@/shared/ui/Modal';
+import { cookies } from 'next/headers';
+
+const ProductReviewEditModal = () => {
+  const accessToken = cookies().get('accessToken')?.value ?? '';
+
+  return (
+    <Modal size="medium" closeIcon>
+      <ReviewEditModal accessToken={accessToken} />
+    </Modal>
+  );
+};
+
+export default ProductReviewEditModal;

--- a/src/app/oauth/google/register/page.tsx
+++ b/src/app/oauth/google/register/page.tsx
@@ -5,7 +5,7 @@ import { useSearchParams } from 'next/navigation';
 
 const OauthSignUp = () => {
   const params = useSearchParams();
-  const idToken = params.get('id_token');
+  const idToken = params?.get('id_token');
 
   if (idToken) {
     return (

--- a/src/app/oauth/kakao/page.tsx
+++ b/src/app/oauth/kakao/page.tsx
@@ -7,7 +7,7 @@ import { useEffect } from 'react';
 
 const Oauth = () => {
   const searchParams = useSearchParams();
-  const authorizationCode = searchParams.get('code');
+  const authorizationCode = searchParams?.get('code');
 
   const signInMutation = useSignInMutation('kakao');
 

--- a/src/app/oauth/kakao/register/page.tsx
+++ b/src/app/oauth/kakao/register/page.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 
 const OauthSignUp = () => {
   const searchParams = useSearchParams();
-  const authorizationCode = searchParams.get('code');
+  const authorizationCode = searchParams?.get('code');
 
   useEffect(() => {
     if (!authorizationCode) {

--- a/src/components/Detail/ProductDetail/ProductDetail.tsx
+++ b/src/components/Detail/ProductDetail/ProductDetail.tsx
@@ -46,7 +46,7 @@ export const ProductDetail = ({
   };
 
   return (
-    <div className="mobile:mt-[30px] md:mt-[44px] lg:mt-[64px] lg:mb-[20px] flex mobile:flex-col justify-center items-center md:items-start lg:items-start gap-[20px] lg:gap-[40px]">
+    <div className="w-full mobile:mt-[30px] md:mt-[44px] lg:mt-[64px] lg:mb-[20px] flex mobile:flex-col justify-center items-center md:items-start lg:items-start gap-[20px] lg:gap-[40px]">
       <div className="flex justify-center items-center">
         <div className="shrink-0 overflow-hidden rounded-lg mobile:w-[335px] mobile:h-[236px] md:w-[280px] md:h-[197px] lg:w-[355px] lg:h-[250px]">
           <ImageComponent
@@ -56,7 +56,7 @@ export const ProductDetail = ({
           />
         </div>
       </div>
-      <div className="flex flex-col gap-[60px]">
+      <div className="w-full flex flex-col gap-[60px]">
         <div className="flex flex-col gap-[20px] md:gap-[50px] lg:gap-[50px]">
           <div className="flex flex-col gap-[10px]">
             <CategoryChip categoryID={productDetailData.categoryId} />

--- a/src/components/Detail/ProductDetail/ShareButtons.tsx
+++ b/src/components/Detail/ProductDetail/ShareButtons.tsx
@@ -19,7 +19,7 @@ interface ShareButtonsProps {
 export const ShareButtons = ({ productName }: ShareButtonsProps) => {
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const order = searchParams.get('order');
+  const order = searchParams?.get('order');
 
   const url = order
     ? `${process.env.NEXT_PUBLIC_FE_URL}${pathname}?order=${order}`

--- a/src/components/Detail/ProductReviews/ControlButtons.tsx
+++ b/src/components/Detail/ProductReviews/ControlButtons.tsx
@@ -1,18 +1,27 @@
 'use client';
 
-import { ControlButtonsProps } from '@/components/Detail/types';
+import {
+  ControlButtonsProps,
+  ProductDetailData,
+} from '@/components/Detail/types';
 import { useQueryClient } from '@tanstack/react-query';
 import { useDeleteReviewMutation } from '@/components/Detail/ProductReviews/hooks';
+import { useRouter } from 'next/navigation';
+import { productKeys } from '@/app/[category]/[product]/queryKeyFactories';
 
 export const ControlButtons = ({
   accessToken,
   reviewId,
   productId,
   filter,
+  rating,
 }: ControlButtonsProps) => {
   const currentFilter = filter ?? 'recent';
 
   const queryClient = useQueryClient();
+  const productData = queryClient.getQueryData<ProductDetailData>(
+    productKeys.detail(productId),
+  );
 
   const deleteReviewMutation = useDeleteReviewMutation(
     queryClient,
@@ -26,8 +35,12 @@ export const ControlButtons = ({
     deleteReviewMutation.mutate();
   };
 
+  const router = useRouter();
   const handleEditClick = () => {
-    alert('리뷰 수정 모달 열림');
+    router.push(
+      `/modal/detail/reviewEdit?reviewId=${reviewId}&rating=${rating}&product=${productId}&category=${productData?.categoryId}&name=${productData?.name}&filter=${currentFilter}`,
+      { scroll: false },
+    );
   };
 
   return (

--- a/src/components/Detail/ProductReviews/ReviewCard.tsx
+++ b/src/components/Detail/ProductReviews/ReviewCard.tsx
@@ -38,6 +38,7 @@ export const ReviewCard = ({
                 reviewId={reviewData.id}
                 productId={reviewData.productId}
                 filter={filter}
+                rating={reviewData.rating}
               />
             )}
           </div>

--- a/src/components/Detail/ProductReviews/ReviewProfile.tsx
+++ b/src/components/Detail/ProductReviews/ReviewProfile.tsx
@@ -26,11 +26,13 @@ export const ReviewProfile = ({ rating, reviewUser }: ReviewProfileProps) => {
       className="lg:h-[42px] md:h-[36px] mobile:h-[36px] flex items-center gap-[10px]"
       href={`/profile?userId=${reviewUser.id}`}
     >
-      <ImageComponent
-        type="profile"
-        src={`${reviewUser.image ?? PROFILE_DEFAULT_IMAGE}`}
-        alt={`${reviewUser.nickname}의 프로필`}
-      />
+      <div className="shrink-0">
+        <ImageComponent
+          type="profile"
+          src={`${reviewUser.image ?? PROFILE_DEFAULT_IMAGE}`}
+          alt={`${reviewUser.nickname}의 프로필`}
+        />
+      </div>
       <div className="flex flex-col gap-[5px]">
         <div className="text-sm lg:text-base text-gray-F1 not-italic leading-normal font-normal">
           {reviewUser.nickname}

--- a/src/components/Detail/ProductReviews/hooks/index.ts
+++ b/src/components/Detail/ProductReviews/hooks/index.ts
@@ -1,2 +1,3 @@
 export * from '@/components/Detail/ProductReviews/hooks/useDeleteReviewMutation';
 export * from '@/components/Detail/ProductReviews/hooks/useLikeMutation';
+export * from '@/components/Detail/ProductReviews/hooks/useEditReviewMutation';

--- a/src/components/Detail/ProductReviews/hooks/useEditReviewMutation.ts
+++ b/src/components/Detail/ProductReviews/hooks/useEditReviewMutation.ts
@@ -1,0 +1,49 @@
+import { productKeys } from '@/app/[category]/[product]/queryKeyFactories';
+import { PatchReviewProps, patchReview } from '@/shared/@common/apis';
+import { QueryClient, useMutation } from '@tanstack/react-query';
+import { useRouter } from 'next/navigation';
+
+interface EditReviewProps {
+  accessToken: string;
+  setErrorMessage: (message: string) => void;
+  queryClient: QueryClient;
+  productId: number;
+  currentFilter: string;
+  reviewId: number;
+}
+
+export const useEditReviewMutation = ({
+  accessToken,
+  setErrorMessage,
+  queryClient,
+  productId,
+  currentFilter,
+  reviewId,
+}: EditReviewProps) => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: async (data: PatchReviewProps) => {
+      const response = await patchReview(reviewId, data, accessToken);
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message);
+      }
+      return response.json();
+    },
+    onSuccess: () => {
+      router.back();
+    },
+    onError: (error) => {
+      setErrorMessage(error.message);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({
+        queryKey: productKeys.reviews(productId, currentFilter),
+      });
+      queryClient.invalidateQueries({
+        queryKey: productKeys.detail(productId),
+      });
+    },
+  });
+};

--- a/src/components/Detail/modal/EditModal.tsx
+++ b/src/components/Detail/modal/EditModal.tsx
@@ -30,11 +30,11 @@ export const EditModal = ({ accessToken }: EditModalProps) => {
     mode: 'onChange',
   });
   const params = useSearchParams();
-  const productId = parseInt(params.get('productId') as string, 10);
-  const categoryId = params.get('category') || '';
-  const productName = params.get('productName') || '';
-  const image = params.get('image') || '';
-  const currentFilter = params.get('filter') || '';
+  const productId = parseInt(params?.get('productId') as string, 10);
+  const categoryId = params?.get('category') || '';
+  const productName = params?.get('productName') || '';
+  const image = params?.get('image') || '';
+  const currentFilter = params?.get('filter') || '';
 
   const [file, setFile] = useState<File | null>(null);
   const [preview, setPreview] = useState(image);

--- a/src/components/Detail/modal/ReviewEditModal.tsx
+++ b/src/components/Detail/modal/ReviewEditModal.tsx
@@ -1,0 +1,212 @@
+'use client';
+
+import { useImageMutation } from '@/shared/@common/hooks';
+import { FormValues } from '@/shared/@common/types/input';
+import { Button, ButtonKind } from '@/shared/ui/Button/Button';
+import { CategoryChip } from '@/shared/ui/Chip/CategoryChip';
+import { Icon } from '@/shared/ui/Icon';
+import HelperText from '@/shared/ui/Input/HelperText';
+import { TextBoxInput } from '@/shared/ui/Input/TextBox';
+import { ImageInput } from '@/shared/ui/Input/image';
+import { useState } from 'react';
+import { useSearchParams } from 'next/navigation';
+import { SubmitHandler, useForm } from 'react-hook-form';
+import { useQueryClient } from '@tanstack/react-query';
+import { ALLOWED_TYPES } from '@/shared/@common/utils/constants/Image';
+import { Image } from '@/shared/@common/apis';
+import { useEditReviewMutation } from '../ProductReviews/hooks';
+
+interface ReviewEditModalProps {
+  accessToken: string;
+}
+
+const MAX_SIZE = 5 * 1024 * 1024;
+
+export const ReviewEditModal = ({ accessToken }: ReviewEditModalProps) => {
+  const {
+    register,
+    watch,
+    handleSubmit,
+    formState: { isSubmitting },
+  } = useForm<FormValues>({
+    mode: 'onChange',
+  });
+
+  const params = useSearchParams();
+  const productId = parseInt(params?.get('product') as string, 10) || 0;
+  const prevRating = parseInt(params?.get('rating') as string, 10) || 0;
+  const reviewId = parseInt(params?.get('reviewId') as string, 10) || 0;
+  const categoryId = parseInt(params?.get('category') as string, 10);
+  const productName = params?.get('name') || '';
+  const currentFilter = params?.get('filter') || '';
+
+  const [rating, setRating] = useState(prevRating);
+  const [files, setFiles] = useState<File[]>([]);
+  const [previews, setPreviews] = useState<string[]>([]);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [isPending, setIsPending] = useState(false);
+
+  const ratingColors = Array(5)
+    .fill('fill-gray-6E')
+    .map((color, index) => (rating > index ? 'fill-yellow' : 'fill-gray-6E'));
+
+  const handleStarClick = (index: number) => {
+    setRating(index);
+  };
+
+  const text = watch('textarea', '');
+
+  const queryClient = useQueryClient();
+
+  const imageMutation = useImageMutation({ accessToken, setErrorMessage });
+  const editReviewMutation = useEditReviewMutation({
+    accessToken,
+    setErrorMessage,
+    queryClient,
+    productId,
+    currentFilter,
+    reviewId,
+  });
+
+  const isDisabled =
+    rating === 0 || !text || files.length === 0 || isSubmitting || isPending;
+
+  const handleDeleteButton = (index: number) => {
+    setPreviews((prevPreviews) => prevPreviews.filter((_, i) => i !== index));
+    setFiles((prevFiles) => prevFiles.filter((_, i) => i !== index));
+  };
+
+  const handleImageChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    if (event.target.files && event.target.files.length > 0) {
+      const newFiles = Array.from(event.target.files).slice(
+        0,
+        3 - files.length,
+      );
+      const validFiles = newFiles
+        .filter((file) => {
+          if (file.size > MAX_SIZE) {
+            setErrorMessage('이미지 파일의 최대 용량은 5MB입니다.');
+            return false;
+          }
+
+          if (!ALLOWED_TYPES.includes(file.type)) {
+            setErrorMessage(
+              '허용된 파일 형식은 .jpg, .jpeg, .png, .webp 입니다.',
+            );
+            return false;
+          }
+
+          return true;
+        })
+        .map((file) => {
+          const newFileName = Math.random().toString(36).substring(2, 8);
+          return new File([file], newFileName, { type: file.type });
+        });
+
+      if (validFiles.length > 0) {
+        setFiles((prevFiles) => [...prevFiles, ...validFiles]);
+
+        const newPreviews = validFiles.map((file) => URL.createObjectURL(file));
+        setPreviews((prevPreviews) => [...prevPreviews, ...newPreviews]);
+      }
+    }
+  };
+
+  const convertImageArray = (urls: string[]) => {
+    const newImages: Image[] = [];
+    urls.forEach((url) => {
+      newImages.push({ source: url });
+    });
+
+    return newImages;
+  };
+
+  const onSubmit: SubmitHandler<FormValues> = async () => {
+    setIsPending(true);
+
+    const promises = files.map((file) => {
+      return new Promise<string>((resolve, reject) => {
+        const formData = new FormData();
+        formData.append('image', file);
+
+        imageMutation
+          .mutateAsync(file)
+          .then((data) => resolve(data.url))
+          .catch(() => reject(new Error('Image upload failed')));
+      });
+    });
+
+    try {
+      const urls = await Promise.all(promises);
+      editReviewMutation.mutate({
+        images: convertImageArray(urls),
+        content: text,
+        rating,
+      });
+    } catch (error) {
+      setErrorMessage('이미지 업로드 중 오류가 발생했습니다');
+    }
+  };
+
+  return (
+    <form
+      className="flex flex-col gap-[40px] mobile:gap-5"
+      onSubmit={handleSubmit(onSubmit)}
+    >
+      <div className="flex flex-col gap-[10px]">
+        <CategoryChip categoryID={categoryId} />
+        <span className="text-gray-F1 text-xl lg:text-2xl font-semibold lg:leading-none">
+          {productName}
+        </span>
+      </div>
+      <div className="flex flex-col gap-[10px] md:gap-[15px] lg:gap-5">
+        <div className="flex items-center gap-[15px] lg:gap-5">
+          <p className="text-gray-6E text-sm lg:text-base">별점</p>
+          <div
+            className="flex gap-[2px] lg:gap-[5px]"
+            role="slider"
+            tabIndex={0}
+            aria-valuenow={rating}
+            aria-valuemin={1}
+            aria-valuemax={5}
+          >
+            {ratingColors.map((color, index) => (
+              <Icon
+                key={Math.random()}
+                name="StarIcon"
+                className={`w-8 h-8 mobile:w-7 mobile:h-7 ${color}`}
+                onClick={() => handleStarClick(index + 1)}
+              />
+            ))}
+          </div>
+        </div>
+        <TextBoxInput
+          register={register}
+          text={text}
+          placeholder="리뷰를 작성해 주세요"
+        />
+        <div className="flex mobile:w-[315px] gap-[10px] md:gap-[15px] lg:gap-5 overflow-x-auto scrollbar-hide">
+          {previews.length < 3 && (
+            <ImageInput previewImage="" handleImageChange={handleImageChange} />
+          )}
+          {previews.map((preview, index) => (
+            <ImageInput
+              key={Math.random()}
+              previewImage={preview}
+              handleDeleteButton={() => handleDeleteButton(index)}
+            />
+          ))}
+        </div>
+        {errorMessage && <HelperText type="error">{errorMessage}</HelperText>}
+      </div>
+      <Button
+        type="submit"
+        kind={ButtonKind.primary}
+        customSize="lg:text-lg w-[295px] md:w-[510px] lg:w-[540px] h-[50px] md:h-[55px] lg:h-[65px]"
+        disabled={isDisabled}
+      >
+        작성하기
+      </Button>
+    </form>
+  );
+};

--- a/src/components/Detail/modal/ReviewModal.tsx
+++ b/src/components/Detail/modal/ReviewModal.tsx
@@ -38,10 +38,10 @@ export const ReviewModal = ({ accessToken }: ReviewModalProps) => {
   const [isPending, setIsPending] = useState(false);
 
   const params = useSearchParams();
-  const productId = parseInt(params.get('product') as string, 10);
-  const categoryId = parseInt(params.get('category') as string, 10);
-  const productName = params.get('name') || '';
-  const currentFilter = params.get('filter') || '';
+  const productId = parseInt(params?.get('product') as string, 10);
+  const categoryId = parseInt(params?.get('category') as string, 10);
+  const productName = params?.get('name') || '';
+  const currentFilter = params?.get('filter') || '';
 
   const ratingColors = Array(5)
     .fill('fill-gray-6E')

--- a/src/components/Detail/modal/index.ts
+++ b/src/components/Detail/modal/index.ts
@@ -1,2 +1,3 @@
 export * from './ReviewModal';
 export * from './EditModal';
+export * from './ReviewEditModal';

--- a/src/components/Detail/types/productReviewsType.ts
+++ b/src/components/Detail/types/productReviewsType.ts
@@ -27,6 +27,7 @@ export interface ControlButtonsProps {
   reviewId: number;
   productId: number;
   filter: string | undefined;
+  rating: number;
 }
 
 export interface ReviewLikeButtonProps {

--- a/src/components/Profile/ActivitySection/ActivityCard.tsx
+++ b/src/components/Profile/ActivitySection/ActivityCard.tsx
@@ -13,7 +13,7 @@ export const ActivityCard = ({
   loginedId,
   accessToken,
 }: ActivityCardProps) => {
-  const userId = useSearchParams().get('userId');
+  const userId = useSearchParams()?.get('userId');
   const currentProfileId = Number(userId) || Number(loginedId);
 
   const { data: currentUserInfo } = useSuspenseQuery(

--- a/src/components/Profile/ProductSection/ProductSection.tsx
+++ b/src/components/Profile/ProductSection/ProductSection.tsx
@@ -14,8 +14,8 @@ import { useRouter, useSearchParams } from 'next/navigation';
 
 export const ProductSection = ({ loginedId }: { loginedId: number | null }) => {
   const router = useRouter();
-  const userId = useSearchParams().get('userId');
-  const currentMenu = useSearchParams().get('tab') ?? 'reviewedProduct';
+  const userId = useSearchParams()?.get('userId');
+  const currentMenu = useSearchParams()?.get('tab') ?? 'reviewedProduct';
   const currentProfileId = Number(userId) || Number(loginedId);
 
   const [activeMenu, setActiveMenu] = useState('리뷰 남긴 상품');

--- a/src/components/Profile/ProfileCard.tsx
+++ b/src/components/Profile/ProfileCard.tsx
@@ -19,8 +19,8 @@ interface ProfileCardProps {
 
 export const ProfileCard = ({ loginedId, accessToken }: ProfileCardProps) => {
   const router = useRouter();
-  const userId = useSearchParams().get('userId');
-  const tab = useSearchParams().get('tab') ?? TAB_NAMES_ORIGIN.reviewedProduct;
+  const userId = useSearchParams()?.get('userId');
+  const tab = useSearchParams()?.get('tab') ?? TAB_NAMES_ORIGIN.reviewedProduct;
   const currentProfileId = Number(userId) || Number(loginedId);
   const isMyProfile = Number(userId) === Number(loginedId) || !userId;
 

--- a/src/components/Profile/modal/UserListModal.tsx
+++ b/src/components/Profile/modal/UserListModal.tsx
@@ -27,8 +27,8 @@ interface UserListModalProps {
 }
 const UserListModal = ({ accessToken, loginedId }: UserListModalProps) => {
   const searchParams = useSearchParams();
-  const userId = Number(searchParams.get('userId')) ?? loginedId;
-  const followType = searchParams.get('type') ?? 'follower';
+  const userId = Number(searchParams?.get('userId')) ?? loginedId;
+  const followType = searchParams?.get('type') ?? 'follower';
   const isFollowerList = followType === 'follower';
 
   const {

--- a/src/pages/api/health-check.ts
+++ b/src/pages/api/health-check.ts
@@ -1,0 +1,6 @@
+import { NextApiHandler } from 'next';
+
+const handler: NextApiHandler = (_, res) =>
+  res.status(200).json({ status: 'OK' });
+
+export default handler;

--- a/src/shared/@common/apis/review.ts
+++ b/src/shared/@common/apis/review.ts
@@ -7,12 +7,12 @@ export interface PostReviewProps {
   rating: number;
 }
 
-interface Image {
+export interface Image {
   id?: number;
   source?: string;
 }
 
-interface PatchReviewProps {
+export interface PatchReviewProps {
   images: Image[];
   content: string;
   rating: number;

--- a/src/shared/ui/Img/ImageComponent.tsx
+++ b/src/shared/ui/Img/ImageComponent.tsx
@@ -5,7 +5,7 @@ import { twMerge } from 'tailwind-merge';
 const typeClasses: Record<ImageProps['type'], string> = {
   product: 'w-full aspect-[284/200] rounded-lg overflow-hidden object-cover',
   profile:
-    'mobile:w-[36px] mobile:h-[36px] md:w-[36px] md:w-[36px] lg:w-[42px] lg:h-[42px] rounded-full overflow-hidden',
+    'mobile:w-[36px] mobile:h-[36px] md:w-[36px] md:h-[36px] lg:w-[42px] lg:h-[42px] rounded-full overflow-hidden',
   review:
     'mobile:w-[60px] mobile:h-[60px] md:w-[80px] md:h-[80px] lg:w-[100px] lg:h-[100px]',
   detail:

--- a/src/shared/ui/Menu/Gnb/GnbSearch.tsx
+++ b/src/shared/ui/Menu/Gnb/GnbSearch.tsx
@@ -18,7 +18,8 @@ const GnbSearchBar = ({
 }: GnbSearchBarProps) => {
   const { register, handleSubmit, setValue } = useForm<SearchInput>();
   const router = useRouter();
-  const { category } = useParams();
+  const params = useParams<{ category: string }>();
+  const category = params?.category;
   const pathname = usePathname();
   // 검색어 상태 관리
   const searchTerm = useSearchStore((state) => state.searchTerm);


### PR DESCRIPTION
## #️⃣연관된 이슈

> #169 

## 📝작업 내용

> 1. HTTPS 적용을 위한 health-check api 생성
> 2. 클립보드 복사 에러 해결
> 3. 상품 상세 페이지 상품 설명이 짧을 때 UI 깨지는 문제 해결
> 4. 리뷰 수정하기 연결
> 5. 자잘한 스타일 수정

## 스크린샷
<img width="683" alt="스크린샷 2024-06-22 03 45 59" src="https://github.com/Codeit-Part4-SFJs/WDYTA/assets/155162841/deaede95-4b27-4797-9333-e22a81874ad8">

## 💬리뷰 요구사항(선택)

> EC2 인스턴스가 살아있는지 체크하는 health-check api 만들었습니다. 별거 아니고 AWS 콘솔에서 주기적으로 해당 엔드포인트로 요청 보내고 200 응답 받으면 인스턴스에 배포된 컨테이너가 잘 구동중이라는걸 확인하는 api 입니다. 해당 api를 이용하여 https를 유지합니다.

> 클립보드 복사 에러는 HTTPS 적용 이후 해결 되었습니다.

> 자잘한 UI 스타일 수정했고, 공통 이미지 컴포넌트에 프로필 이미지가 테블릿일 때 높이값이 없고 w 만 두번 있길래 이부분 수정했습니다.

> 리뷰 수정하기 연결했고, 수정 하고 바로 리뷰에 데이터 반영됩니다.